### PR TITLE
Fix compilation error

### DIFF
--- a/Color.h
+++ b/Color.h
@@ -6,8 +6,10 @@
 #endif
 
 namespace cairowindow {
+#ifdef CWDEBUG
 // This class defines a print_on method.
 using utils::has_print_on::operator<<;
+#endif
 
 class Color
 {

--- a/Rectangle.h
+++ b/Rectangle.h
@@ -7,8 +7,10 @@
 #endif
 
 namespace cairowindow {
+#ifdef CWDEBUG
 // This class defines a print_on method.
 using utils::has_print_on::operator<<;
+#endif
 
 class Rectangle
 {


### PR DESCRIPTION
The compiler says, that it can't find namespace utils without it.

```
CarloWood/machine-learning/cairowindow/Color.h:10:7: error: ‘utils’ has not been declared
   10 | using utils::has_print_on::operator<<;
      |       ^~~~~

```